### PR TITLE
add zk authInfo support

### DIFF
--- a/lib/registry/zk/data_client.js
+++ b/lib/registry/zk/data_client.js
@@ -33,7 +33,8 @@ class ZookeeperRegistry extends Base {
       this._rootPath = '/sofa-rpc/';
     }
     const cluster = options.cluster;
-    this._zkClient = this.options.zookeeper.createClient(address, { cluster });
+    const authInfo = options.authInfo;
+    this._zkClient = this.options.zookeeper.createClient(address, { cluster, authInfo });
     this._zkClient.on('connected', () => {
       this.emit('connected');
       this._reRegister();


### PR DESCRIPTION
连接zk时可能需要acl认证支持。配合zookeeper-cluster-client,在registry的配置信息中添加authInfo,即可自动调用node-zookeeper-client的addAuthInfo方法进行认证。示例：

const { ZookeeperRegistry } = require('sofa-rpc-node').registry;

// create zk registry client
const registry = new ZookeeperRegistry({
address: '127.0.0.1:2181',
authInfo: { scheme: 'digest', auth: 'user:password' },
});