### PR TITLE
fix pathname if protocol use dubbo

### DIFF
--- a/lib/server/service.js
+++ b/lib/server/service.js
@@ -52,6 +52,9 @@ class RpcService extends Base {
     url.searchParams.set('interface', this.interfaceName);
     url.searchParams.set('version', this.version);
     url.searchParams.set('group', this.group);
+    if(Object.is(url.protocol, 'dubbo:')){
+      url.pathname = this.interfaceName;
+    }
     const reg = {
       interfaceName: this.interfaceName,
       version: this.version,


### PR DESCRIPTION
我们发现使用dubbo提供rpc时，客户端无法调用，经排查，注册到zk的url缺少了pathname部分，这部分在dubbo的官方文档中是表示 `接口名称` 参考链接：https://dubbo.apache.org/zh-cn/blog/introduction-to-dubbo-url.html

> Dubbo 中的 URL
> 在 dubbo 中，也使用了类似的 URL，主要用于在各个扩展点之间传递数据，组成此 URL 对象的具体参数如下:
> protocol：一般是 dubbo 中的各种协议 如：dubbo thrift http zk
> username/password：用户名/密码
> host/port：主机/端口
> path：接口名称
> parameters：参数键值对

我修改了这部分之后，rpc服务能正常处理和返回数据了，请大神帮看看是否需要合并。

我是在egg-cloud中尝试这些操作的，原来java提供的url在zk中类似这样（我进行了URL decode）：
`dubbo://192.168.1.2:9001/com.aa.service.bb.QrySss?accepts=500&anyhost=true&application=acc-provider&application.version=3.0.0&dubbo=2.8.4&extension=com.alibaba.dubbo.rpc.protocol.rest.support.LoggingFilter&generic=false&interface=com.aa.service.bb.QrySss&logger=slf4j&methods=getPasswd&pid=6424&revision=3.0.0&side=provider&threadpool=fixed&threads=500&timeout=6000&timestamp=1572229801096&version=3.0.1`

而采用egg-cloud，结果得到的url是类似这样的
`
dubbo://192.168.1.3:9003?startTime=1576134121816&pid=46675&uniqueId=&dynamic=true&appName=cloud-serv&timeout=3000&serialization=hessian2&weight=100&accepts=100000&language=nodejs&rpcVer=50400&protocol=dubbo&interface=com.aa.service.bb.QrySss&version=3.0.1&group=-
`




