### PR TITLE
egg的rpc.server支持customMeta配置，用于支持自定义元数据；

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "eslint-config-egg"
+  "extends": "eslint-config-egg",
+  "rules": {
+    "dot-notation": "off"
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,3 @@
 {
-  "extends": "eslint-config-egg",
-  "rules": {
-    "dot-notation": "off"
-  }
+  "extends": "eslint-config-egg"
 }

--- a/lib/server/service.js
+++ b/lib/server/service.js
@@ -17,17 +17,9 @@ class RpcService extends Base {
     this.version = options.version;
     this.uniqueId = options.uniqueId;
     this.group = options.group;
-    // 获取自定义元数据键数组
-    // get custom metadata key array
-    this.metaKey = is.array(options.metaKey) ? options.metaKey.filter(key => key !== 'metaKey') : [];
     // 获取自定义元数据
-    // assign custom metadata
-    this.metaKey.forEach(metaKey => {
-      const value = options[metaKey];
-      if (typeof value !== 'undefined') {
-        this[metaKey] = value;
-      }
-    });
+    // get custom metadata
+    this.customMeta = typeof options.customMeta === 'object' ? options.customMeta : {};
 
     this.id = this.uniqueId ?
       this.interfaceName + ':' + this.version + ':' + this.uniqueId :
@@ -66,8 +58,8 @@ class RpcService extends Base {
     // 写入自定义元数据
     // append custom metadata to searchParams
     let customMeta = {};
-    this.metaKey.forEach(metaKey => {
-      const value = this[metaKey];
+    Object.keys(this.customMeta).forEach(metaKey => {
+      const value = this.customMeta[metaKey];
       if (typeof value !== 'undefined') {
         url.searchParams.set(metaKey, value);
         const source = { [`${metaKey}`]: value };

--- a/lib/server/service.js
+++ b/lib/server/service.js
@@ -58,9 +58,10 @@ class RpcService extends Base {
     // 写入自定义元数据
     // append custom metadata to searchParams
     let customMeta = {};
+    const blockList = [ 'interface', 'version', 'group' ];
     Object.keys(this.customMeta).forEach(metaKey => {
       const value = this.customMeta[metaKey];
-      if (typeof value !== 'undefined') {
+      if (!(typeof value === 'undefined' || blockList.includes(metaKey))) {
         url.searchParams.set(metaKey, value);
         const source = { [`${metaKey}`]: value };
         customMeta = Object.assign(customMeta, source);

--- a/lib/server/service.js
+++ b/lib/server/service.js
@@ -17,6 +17,15 @@ class RpcService extends Base {
     this.version = options.version;
     this.uniqueId = options.uniqueId;
     this.group = options.group;
+    // 获取自定义元数据键数组
+    this.metaKey = is.array(options.metaKey) ? options.metaKey.filter(key => key === 'metaKey') : [];
+    // 获取自定义元数据
+    this.metaKey.forEach(metaKey => {
+      const value = options[metaKey];
+      if (typeof value !== 'undefined') {
+        this[metaKey] = value;
+      }
+    });
 
     this.id = this.uniqueId ?
       this.interfaceName + ':' + this.version + ':' + this.uniqueId :
@@ -52,13 +61,23 @@ class RpcService extends Base {
     url.searchParams.set('interface', this.interfaceName);
     url.searchParams.set('version', this.version);
     url.searchParams.set('group', this.group);
+    // 写入自定义元数据
+    let customMeta = {};
+    this.metaKey.forEach(metaKey => {
+      const value = this[metaKey];
+      if (typeof value !== 'undefined') {
+        url.searchParams.set(metaKey, value);
+        const source = { [`${metaKey}`]: value };
+        customMeta = Object.assign(customMeta, source);
+      }
+    });
     const reg = {
       interfaceName: this.interfaceName,
       version: this.version,
       group: this.group,
       url: url.toString(),
     };
-    return reg;
+    return Object.assign(reg, customMeta);
   }
 
   /**

--- a/lib/server/service.js
+++ b/lib/server/service.js
@@ -19,7 +19,7 @@ class RpcService extends Base {
     this.group = options.group;
     // 获取自定义元数据键数组
     // get custom metadata key array
-    this.metaKey = is.array(options.metaKey) ? options.metaKey.filter(key => key === 'metaKey') : [];
+    this.metaKey = is.array(options.metaKey) ? options.metaKey.filter(key => key !== 'metaKey') : [];
     // 获取自定义元数据
     // assign custom metadata
     this.metaKey.forEach(metaKey => {

--- a/lib/server/service.js
+++ b/lib/server/service.js
@@ -18,8 +18,10 @@ class RpcService extends Base {
     this.uniqueId = options.uniqueId;
     this.group = options.group;
     // 获取自定义元数据键数组
+    // get custom metadata key array
     this.metaKey = is.array(options.metaKey) ? options.metaKey.filter(key => key === 'metaKey') : [];
     // 获取自定义元数据
+    // assign custom metadata
     this.metaKey.forEach(metaKey => {
       const value = options[metaKey];
       if (typeof value !== 'undefined') {
@@ -62,6 +64,7 @@ class RpcService extends Base {
     url.searchParams.set('version', this.version);
     url.searchParams.set('group', this.group);
     // 写入自定义元数据
+    // append custom metadata to searchParams
     let customMeta = {};
     this.metaKey.forEach(metaKey => {
       const value = this[metaKey];

--- a/test/server/service-custom-metadata.test.js
+++ b/test/server/service-custom-metadata.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const mm = require('mm');
+const assert = require('assert');
+const RpcService = require('../../').server.RpcService;
+const logger = console;
+
+describe('test/server/service-custom-metadata.test.js', () => {
+  afterEach(mm.restore);
+  it('should work ok', async function() {
+    assert.throws(() => {
+      new RpcService();
+    }, null, '[RpcService] options.interfaceName is required');
+
+    const service = new RpcService({
+      interfaceName: 'com.node.test.TestService',
+      version: '1.0',
+      appName: 'test',
+      group: 'SOFA',
+      logger,
+      apiMeta: {
+        methods: [{
+          name: 'plus',
+          parameterTypes: [
+            'java.lang.Integer',
+            'java.lang.Integer',
+          ],
+          returnType: 'java.lang.Integer',
+        }],
+      },
+      customMeta: {
+        release: '2.7.4.1',
+      },
+      delegate: {
+        async plus(a, b) {
+          return a + b;
+        },
+      },
+    });
+    await service.ready();
+
+    assert(!service.app);
+    assert(!service.registry);
+    assert(!service.classMaps);
+
+    assert.deepEqual(service.normalizeReg('bolt://127.0.0.1:12200'), {
+      interfaceName: 'com.node.test.TestService',
+      version: '1.0',
+      group: 'SOFA',
+      url: 'bolt://127.0.0.1:12200?interface=com.node.test.TestService&version=1.0&group=SOFA',
+    });
+
+    await service.publish('bolt://127.0.0.1:12200');
+    assert(!service.publishUrl);
+    await service.unPublish();
+
+    const ctx = {};
+    const req = {
+      data: {
+        methodName: 'plus',
+        args: [ 1, 2 ],
+      },
+      options: {
+        timeout: 3000,
+      },
+    };
+    const res = {
+      isClosed: true,
+      meta: {},
+      remoteAddress: '127.0.0.1',
+    };
+    let executed = false;
+    mm(service.logger, 'warn', message => {
+      assert(message === '[RpcService] client maybe closed before sending response, remote address: %s');
+      executed = true;
+    });
+    await service.invoke(ctx, req, res);
+    assert(executed);
+  });
+});

--- a/test/server/service-custom-metadata.test.js
+++ b/test/server/service-custom-metadata.test.js
@@ -47,7 +47,8 @@ describe('test/server/service-custom-metadata.test.js', () => {
       interfaceName: 'com.node.test.TestService',
       version: '1.0',
       group: 'SOFA',
-      url: 'bolt://127.0.0.1:12200?interface=com.node.test.TestService&version=1.0&group=SOFA',
+      release: '2.7.4.1',
+      url: 'bolt://127.0.0.1:12200?interface=com.node.test.TestService&version=1.0&group=SOFA&release=2.7.4.1',
     });
 
     await service.publish('bolt://127.0.0.1:12200');


### PR DESCRIPTION
因为最近发现nacos服务在元数据的release字段不匹配时会报以下内容（特别是为Java spring boot提供服务时）
en: When a nacos service is found not to match the [release] field of metadata, the following will be print (especially when providing services for Java spring boot project)

> No provider available from registry ** for service ** on consumer ** use dubbo version 2.7.4.1, please check status of providers(disabled, not registered or in blacklist).

因此加入了对egg的config.rpc.server.customMeta的兼容，使用实例如下：
en: so, this cl support eggjs framework config file filled [config.rpc.server.customMeta]: 
```js
module.exports => {
  rpc: {
    registry: {
      type: 'nacos',
      address: '192.168.1.100:8848',
      namespace: 'public'
    },
    server: {
      port: 12200,
      namespace: 'com.chansos.nodejs.service.TestService',
      version: '1.0.0',
      group: '',
      customMeta: {
        release: '2.7.4.1'
      }
    }
  }
}
```

nacos中对应服务的元数据如下：
en: nacos service can found this metadata: 
```json
{
	"accepts": "100000",
	"appName": "chansos-nodejs-service",
	"release": "2.7.4.1",
	"weight": "100",
	"pid": "27040",
	"language": "nodejs",
	"interface": "com.chansos.nodejs.service.TestService",
	"version": "1.0.0",
	"timeout": "3000",
	"serialization": "hessian2",
	"protocol": "dubbo",
	"startTime": "1590998139678",
	"dynamic": "true",
	"uniqueId": "",
	"rpcVer": "50400",
	"group": ""
}
```