### PR TITLE
fix: create consumer with cache: false, will not override client._consumerCache map (#71)

### DIFF
--- a/lib/client/client.js
+++ b/lib/client/client.js
@@ -95,13 +95,17 @@ class RpcClient extends Base {
       debug('create consumer for %s', key);
       consumerClass = consumerClass || this.consumerClass;
       consumer = new consumerClass(options);
-      this._consumerCache.set(key, consumer);
+      if (options.cache) {
+        this._consumerCache.set(key, consumer);
+      }
       // delegate consumer's error to client
       consumer.on('error', err => { this.emit('error', err); });
       consumer.on('request', req => { this.emit('request', req); });
       consumer.on('response', info => { this.emit('response', info); });
       consumer.once('close', () => {
-        this._consumerCache.delete(key);
+        if (options.cache) {
+          this._consumerCache.delete(key);
+        }
       });
     }
     return consumer;


### PR DESCRIPTION
fix chery pick: https://github.com/sofastack/sofa-rpc-node/pull/71