### PR TITLE
feat: 运行覆盖 ConnectionManager 初始化链接异常消息

### DIFF
--- a/lib/client/connection_mgr.js
+++ b/lib/client/connection_mgr.js
@@ -65,6 +65,11 @@ class ConnectionManager extends Base {
     this._connections.delete(address.host);
   }
 
+  // 记录 connection 启动异常消息，可按需覆盖展示逻辑
+  logConnectErrorMessage(message) {
+    this.logger.info(message);
+  }
+
   /**
    * 若不存在，则创建新的连接
    *
@@ -95,7 +100,8 @@ class ConnectionManager extends Base {
             currentSize, this._warnConnectionCount);
         }
       } catch (err) {
-        this.logger.warn('[ConnectionManager] create connection: ' + address.href + ' failed, caused by ' + err.message);
+        const message = `[ConnectionManager] create connection: ${address.href} failed, caused by ${err.message}`;
+        this.logConnectErrorMessage(message);
         this.doDeleteConn(address);
         return null;
       }

--- a/test/client/address_group.test.js
+++ b/test/client/address_group.test.js
@@ -836,7 +836,7 @@ describe('test/client/address_group.test.js', () => {
 
           const count = addressGroup._weightMap.get(address.host);
           // unstable assert
-          assert(count=== 10 || count >= 5);
+          assert(count === 10 || count >= 5);
         } else {
           assert(connection && connection.latestHealthCount);
           const hc = connection.latestHealthCount;

--- a/test/client/connection_mgr.test.js
+++ b/test/client/connection_mgr.test.js
@@ -11,10 +11,14 @@ const util = require('util');
 describe('test/client/connection_mgr.test.js', () => {
   describe('connection count great than warn count', () => {
     let warnLog;
+    let infoLog;
     beforeEach(async () => {
       await utils.startServer(13201);
       mm(logger, 'warn', (...params) => {
         warnLog = util.format(...params);
+      });
+      mm(logger, 'info', (...params) => {
+        infoLog = util.format(...params);
       });
     });
 
@@ -32,6 +36,33 @@ describe('test/client/connection_mgr.test.js', () => {
       assert(/\[ConnectionManager] current connection count is 1, great than warn count 0/.test(warnLog));
       await conn.close();
       await mgr.close();
+    });
+
+    it('should print connect error message', async () => {
+      const mgr = new ConnectionManager({
+        logger,
+      });
+      const conn = await mgr.createAndGet(urlparse('bolt://127.0.0.1:43999', true), {});
+      assert(infoLog);
+      assert(/\[ConnectionManager] create connection: bolt:\/\/127.0.0.1:43999 failed, caused by connect ECONNREFUSED 127.0.0.1:43999/.test(infoLog));
+      assert(conn === null);
+      await mgr.close();
+
+      // override logConnectErrorMessage
+      let fooMessage = '';
+      class CustomConnectionManager extends ConnectionManager {
+        logConnectErrorMessage(message) {
+          fooMessage = message;
+        }
+      }
+      const mgr2 = new CustomConnectionManager({
+        logger,
+      });
+      const conn2 = await mgr2.createAndGet(urlparse('bolt://127.0.0.1:43999', true), {});
+      assert(fooMessage);
+      assert(/\[ConnectionManager] create connection: bolt:\/\/127.0.0.1:43999 failed, caused by connect ECONNREFUSED 127.0.0.1:43999/.test(fooMessage));
+      assert(conn2 === null);
+      await mgr2.close();
     });
   });
 });


### PR DESCRIPTION
让应用框架可以在本地开发阶段不输出这些干扰的错误信息