### PR TITLE
feat: 增加balancerFilter优先匹配

### DIFF
--- a/lib/client/address_group.js
+++ b/lib/client/address_group.js
@@ -340,25 +340,17 @@ class AddressGroup extends Base {
     return weight;
   }
 
-  async getFilterConnection(req) {
-    try {
-      return await this.getConnectionDefault(req, true);
-    } catch (error) {
-      // 兜底，connect异常，说明host不可用
-      if (error.message === "Cannot read property 'host' of undefined" && error.name === 'TypeError') {
-        this.logger.info('[AddressGroup] getFilterConnection error, will retry getConnectionDefault', error);
-        return null;
-      }
-      throw error;
-    }
-  }
-
   async getConnection(req) {
     const hasFilter = typeof this.options.balancerFilter === 'function';
     // 增加一层filter判断，若正常则直接返回，否则走原 getConnection 逻辑
     if (hasFilter) {
-      const filterConnection = await this.getFilterConnection(req);
-      if (filterConnection) return filterConnection;
+      try {
+        const filterConnection = await this.getConnectionDefault(req, true);
+        if (filterConnection) return filterConnection;
+      } catch (error) {
+        // filter 地址都失败后，多走一次原 getConnection 逻辑
+        this.logger.info('[AddressGroup] filterConnection error', error);
+      }
     }
     return await this.getConnectionDefault(req);
   }

--- a/lib/client/address_group.js
+++ b/lib/client/address_group.js
@@ -356,9 +356,11 @@ class AddressGroup extends Base {
   async getConnection(req) {
     const hasFilter = typeof this.options.balancerFilter === 'function';
     // 增加一层filter判断，若正常则直接返回，否则走原 getConnection 逻辑
-    const filterConnection = await hasFilter ? await this.getFilterConnection(req) : null;
-    if (filterConnection) return filterConnection;
-    return this.getConnectionDefault(req);
+    if (hasFilter) {
+      const filterConnection = await this.getFilterConnection(req);
+      if (filterConnection) return filterConnection;
+    }
+    return await this.getConnectionDefault(req);
   }
 
   async getConnectionDefault(req, needFilter) {

--- a/lib/client/address_group.js
+++ b/lib/client/address_group.js
@@ -340,11 +340,32 @@ class AddressGroup extends Base {
     return weight;
   }
 
+  async getFilterConnection(req) {
+    try {
+      return await this.getConnectionDefault(req, true);
+    } catch (error) {
+      // 兜底，connect异常，说明host不可用
+      if (error.message === "Cannot read property 'host' of undefined" && error.name === 'TypeError') {
+        this.logger.info('[AddressGroup] getFilterConnection error, will retry getConnectionDefault', error);
+        return null;
+      }
+      throw error;
+    }
+  }
+
   async getConnection(req) {
+    const hasFilter = typeof this.options.balancerFilter === 'function';
+    // 增加一层filter判断，若正常则直接返回，否则走原 getConnection 逻辑
+    const filterConnection = await hasFilter ? await this.getFilterConnection(req) : null;
+    if (filterConnection) return filterConnection;
+    return this.getConnectionDefault(req);
+  }
+
+  async getConnectionDefault(req, needFilter) {
     const meta = req.meta;
     meta.connectionGroup = this.key;
 
-    const address = this._loadbalancer.select(req);
+    const address = this._loadbalancer.select(req, needFilter);
     if (!address) return null;
 
     const { connectionOpts, connectionClass } = this.options;

--- a/lib/client/loadbalancer/base.js
+++ b/lib/client/loadbalancer/base.js
@@ -26,6 +26,7 @@ class LoadBalancer extends Base {
   select(request, needFilter) {
     // 需要时才需要过滤
     const hasFilter = needFilter && typeof this.addressGroup.options.balancerFilter === 'function';
+    this.inBalancerFilterFilter = false;
     // 透出addressList，供外部进行一次优先筛选
     if (hasFilter) {
       const list = this.addressGroup.options.balancerFilter(

--- a/lib/client/loadbalancer/base.js
+++ b/lib/client/loadbalancer/base.js
@@ -23,7 +23,21 @@ class LoadBalancer extends Base {
     return this.addressGroup.logger;
   }
 
-  select(request) {
+  select(request, needFilter) {
+    // 需要时才需要过滤
+    const hasFilter = needFilter && typeof this.addressGroup.options.balancerFilter === 'function';
+    // 透出addressList，供外部进行一次优先筛选
+    if (hasFilter) {
+      const list = this.addressGroup.options.balancerFilter(
+        this.addressList
+      );
+      if (Array.isArray(list)) {
+        // 若优先筛选后无可用，重新尝试全部地址
+        if (list.length === 0) return this._doSelect(request, this.addressList);
+        // list.length === 1 也进行一次 doSelect，有可能getWeight异常
+        return this._doSelect(request, list);
+      }
+    }
     if (this.size === 0) return null;
     if (this.size === 1) return this.addressList[0];
 

--- a/lib/client/loadbalancer/base.js
+++ b/lib/client/loadbalancer/base.js
@@ -35,7 +35,8 @@ class LoadBalancer extends Base {
         // 若优先筛选后无可用，重新尝试全部地址
         if (list.length === 0) return this._doSelect(request, this.addressList);
         // weight_rr 使用了this.addressList，增加了一个使用传参的filter_rr_doSelect方法
-        return this.filter_rr_doSelect(request, list);
+        this.inBalancerFilterFilter = true;
+        return this._doSelect(request, list);
       }
     }
     if (this.size === 0) return null;

--- a/lib/client/loadbalancer/base.js
+++ b/lib/client/loadbalancer/base.js
@@ -32,15 +32,14 @@ class LoadBalancer extends Base {
       const list = this.addressGroup.options.balancerFilter(
         this.addressList
       );
-      if (Array.isArray(list)) {
-        // 若优先筛选后无可用，重新尝试全部地址
-        if (list.length === 0) return this._doSelect(request, this.addressList);
-        // weight_rr 使用了this.addressList，增加了一个使用传参的filter_rr_doSelect方法
+      if (Array.isArray(list) && list.length > 0) {
         this.inBalancerFilterFilter = true;
-        return this._doSelect(request, list);
+        const address = this._doSelect(request, list);
+        this.inBalancerFilterFilter = false;
+        // 没有数据使用this.addressList重试
+        if (address) return address;
       }
     }
-    this.inBalancerFilterFilter = false;
     if (this.size === 0) return null;
     if (this.size === 1) return this.addressList[0];
 

--- a/lib/client/loadbalancer/base.js
+++ b/lib/client/loadbalancer/base.js
@@ -40,6 +40,7 @@ class LoadBalancer extends Base {
         return this._doSelect(request, list);
       }
     }
+    this.inBalancerFilterFilter = false;
     if (this.size === 0) return null;
     if (this.size === 1) return this.addressList[0];
 

--- a/lib/client/loadbalancer/base.js
+++ b/lib/client/loadbalancer/base.js
@@ -34,8 +34,8 @@ class LoadBalancer extends Base {
       if (Array.isArray(list)) {
         // 若优先筛选后无可用，重新尝试全部地址
         if (list.length === 0) return this._doSelect(request, this.addressList);
-        // list.length === 1 也进行一次 doSelect，有可能getWeight异常
-        return this._doSelect(request, list);
+        // weight_rr 使用了this.addressList，增加了一个使用传参的filter_rr_doSelect方法
+        return this.filter_rr_doSelect(request, list);
       }
     }
     if (this.size === 0) return null;

--- a/lib/client/loadbalancer/weight_rr.js
+++ b/lib/client/loadbalancer/weight_rr.js
@@ -28,6 +28,8 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
   }
 
   _doSelect(request, addressList) {
+    // 存在balancerFilterFilter标识使用filter_doSelect
+    if (this.inBalancerFilterFilter) return this.filter_doSelect(request, addressList);
     let address;
     let count = this.size;
     while (count--) {
@@ -39,7 +41,9 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
   }
 
   // 有balancerFilter时使用外部传入的addressList
-  filter_rr_doSelect(request, addressList) {
+  filter_doSelect(request, addressList) {
+    // 关闭balancerFilterFilter标识
+    this.inBalancerFilterFilter = false;
     let address;
     let count = addressList.length;
     this.filter_offset = utility.random(addressList.length);

--- a/lib/client/loadbalancer/weight_rr.js
+++ b/lib/client/loadbalancer/weight_rr.js
@@ -37,6 +37,31 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
     // 直接返回兜底
     return addressList[this._offset];
   }
+
+  // 有balancerFilter时使用外部传入的addressList
+  filter_rr_doSelect(request, addressList) {
+    let address;
+    let count = addressList.length;
+    this.filter_offset = utility.random(addressList.length);
+    while (count--) {
+      address = this.filter_rr(request, addressList);
+      if (address) return address;
+    }
+    // 直接返回兜底
+    return addressList[this.filter_offset];
+  }
+
+  filter_rr(request, addressList) {
+    const address = addressList[this.filter_offset];
+    this._offset = (this.filter_offset + 1) % addressList.length;
+
+    const weight = this.getWeight(address);
+    if (weight === DEFAULT_WEIGHT) return address;
+    if (weight === 0) return null;
+
+    const randNum = utility.random(DEFAULT_WEIGHT);
+    return weight >= randNum ? address : null;
+  }
 }
 
 module.exports = WeightRoundRobinLoadBalancer;

--- a/lib/client/loadbalancer/weight_rr.js
+++ b/lib/client/loadbalancer/weight_rr.js
@@ -42,8 +42,6 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
 
   // 有balancerFilter时使用外部传入的addressList
   filter_doSelect(request, addressList) {
-    // 关闭balancerFilterFilter标识
-    this.inBalancerFilterFilter = false;
     let address;
     let count = addressList.length;
     this.filter_offset = utility.random(addressList.length);

--- a/lib/client/loadbalancer/weight_rr.js
+++ b/lib/client/loadbalancer/weight_rr.js
@@ -17,7 +17,7 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
 
   _rr(request, addressList) {
     const address = addressList[this._offset];
-    this._offset = (this._offset + 1) % addressList.length;
+    this._offset = (this._offset + 1) % this.size;
 
     const weight = this.getWeight(address);
     if (weight === DEFAULT_WEIGHT) return address;
@@ -29,7 +29,7 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
 
   _doSelect(request, addressList) {
     let address;
-    let count = addressList.length;
+    let count = this.size;
     while (count--) {
       address = this._rr(request, addressList);
       if (address) return address;

--- a/lib/client/loadbalancer/weight_rr.js
+++ b/lib/client/loadbalancer/weight_rr.js
@@ -40,7 +40,7 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
     return addressList[this._offset];
   }
 
-  // 有balancerFilter时使用外部传入的addressList
+  // 原逻辑this.size this.offset使用了this.addressList, 在这里新增一个使用内部addressList的方法
   filter_doSelect(request, addressList) {
     let address;
     let count = addressList.length;
@@ -49,8 +49,8 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
       address = this.filter_rr(request, addressList);
       if (address) return address;
     }
-    // 直接返回兜底
-    return addressList[this.filter_offset];
+    // 全失败
+    return null;
   }
 
   filter_rr(request, addressList) {

--- a/lib/client/loadbalancer/weight_rr.js
+++ b/lib/client/loadbalancer/weight_rr.js
@@ -17,7 +17,7 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
 
   _rr(request, addressList) {
     const address = addressList[this._offset];
-    this._offset = (this._offset + 1) % this.size;
+    this._offset = (this._offset + 1) % addressList.length;
 
     const weight = this.getWeight(address);
     if (weight === DEFAULT_WEIGHT) return address;
@@ -29,7 +29,7 @@ class WeightRoundRobinLoadBalancer extends LoadBalancer {
 
   _doSelect(request, addressList) {
     let address;
-    let count = this.size;
+    let count = addressList.length;
     while (count--) {
       address = this._rr(request, addressList);
       if (address) return address;

--- a/test/client/address_group.test.js
+++ b/test/client/address_group.test.js
@@ -244,6 +244,14 @@ describe('test/client/address_group.test.js', () => {
       assert(connection && connection.isConnected);
       assert(connection.url === 'bolt://127.0.0.1:13201');
     }
+    addressGroup.addressList = [
+      urlparse('bolt://127.0.0.1:13202', true),
+    ];
+    addressGroup._weightMap.set('127.0.0.1:13202', 20);
+    addressGroup._maxIdleWindow = addressGroup._maxIdleWindow + Date.now();
+    const connection = await addressGroup.getConnection(req);
+    assert(connection && connection.isConnected);
+    assert(connection.url === 'bolt://127.0.0.1:13202');
     addressGroup.close();
     await connectionManager.closeAllConnections();
     await utils.closeAll();

--- a/test/client/address_group.test.js
+++ b/test/client/address_group.test.js
@@ -227,6 +227,7 @@ describe('test/client/address_group.test.js', () => {
       urlparse('bolt://127.0.0.1:13203', true),
       urlparse('bolt://127.0.0.1:13204', true),
     ];
+    await addressGroup.ready();
     let count = 3;
     while (count--) {
       const connection = await addressGroup.getConnection(req);

--- a/test/client/address_group.test.js
+++ b/test/client/address_group.test.js
@@ -230,6 +230,7 @@ describe('test/client/address_group.test.js', () => {
       // 优先匹配
       assert(connection.url === 'bolt://127.0.0.1:13202');
     }
+    // 匹配到的数据不可用时，会调用其他地址
     addressGroup.addressList = [
       urlparse('bolt://127.0.0.1:13201', true),
     ];

--- a/test/client/address_group.test.js
+++ b/test/client/address_group.test.js
@@ -207,6 +207,8 @@ describe('test/client/address_group.test.js', () => {
     await Promise.all([
       utils.startServer(13201),
       utils.startServer(13202),
+      utils.startServer(13203),
+      utils.startServer(13204),
     ]);
 
     const addressGroup = new AddressGroup({
@@ -222,8 +224,10 @@ describe('test/client/address_group.test.js', () => {
     addressGroup.addressList = [
       urlparse('bolt://127.0.0.1:13201', true),
       urlparse('bolt://127.0.0.1:13202', true),
+      urlparse('bolt://127.0.0.1:13203', true),
+      urlparse('bolt://127.0.0.1:13204', true),
     ];
-    let count = 10;
+    let count = 3;
     while (count--) {
       const connection = await addressGroup.getConnection(req);
       assert(connection && connection.isConnected);
@@ -238,7 +242,6 @@ describe('test/client/address_group.test.js', () => {
     while (count--) {
       const connection = await addressGroup.getConnection(req);
       assert(connection && connection.isConnected);
-      // 优先匹配
       assert(connection.url === 'bolt://127.0.0.1:13201');
     }
     addressGroup.close();


### PR DESCRIPTION
https://github.com/sofastack/sofa-rpc-node/issues/96

在使用registry的情况下，如果有较多的地址，在这里希望能够进行部分地址增加优先级优先掉用

我的需求： 如地址1、2、3 、4、5、6。希望能够先掉用 1、2、3，并且兜底不可用情况，重新走之前的逻辑 随机掉用1-6

所以在此增加一个`balancerFilter`，在`_loadbalancer.select`之前先掉用一次，筛选出需要优先掉用的地址，优先连接一次。不可用时使用原逻辑。

例子

```js
const { RpcClient } = require('sofa-rpc-node').client;
const { ZookeeperRegistry } = require('sofa-rpc-node').registry;
const logger = console;

// 1. 创建 zk 注册中心客户端
const registry = new ZookeeperRegistry({
  logger,
  address: '127.0.0.1:2181',
});

async function invoke() {
  // 2. 创建 RPC Client 实例
  const client = new RpcClient({
    logger,
    registry,
  });
  // 3. 创建服务的 consumer
  const consumer = client.createConsumer({
    interfaceName: 'com.nodejs.test.TestService',
    balancerFilter: addressList => {
        // 可以重写addressList,进行filter可以实现优先级功能
        // 如: 优先匹配`host === '127.0.0.1:13202'`的地址
        return addressList.filter(v => v.host === '127.0.0.1:13202');
    },
  });
  // 4. 等待 consumer ready（从注册中心订阅服务列表...）
  await consumer.ready();

  // 5. 执行泛化调用
  const result = await consumer.invoke('plus', [ 1, 2 ], { responseTimeout: 3000 });
  console.log('1 + 2 = ' + result);
}

invoke().catch(console.error);
```

