### PR TITLE
chore: add parseRequestPropsWithHeader decode option

### DIFF
--- a/lib/server/connection.js
+++ b/lib/server/connection.js
@@ -48,6 +48,9 @@ class RpcConnection extends Base {
     if (this.options.disableDecodeCache) {
       decodeOpts.classCache = null;
     }
+    if (this.options.parseRequestPropsWithHeader) {
+      decodeOpts.parseRequestPropsWithHeader = this.options.parseRequestPropsWithHeader;
+    }
 
     this.socket.once('close', () => { this._handleClose(); });
     this.socket.once('error', err => { this._handleSocketError(err); });

--- a/lib/server/server.js
+++ b/lib/server/server.js
@@ -245,6 +245,7 @@ class RpcServer extends Base {
       classMap: this.classMap,
       maxIdleTime: this.options.maxIdleTime,
       disableDecodeCache: this.options.disableDecodeCache,
+      parseRequestPropsWithHeader: this.options.parseRequestPropsWithHeader,
     };
     if (this.options.classCacheClass) {
       // 每一个 connection 实例化一个 classCache

--- a/test/registry/edge_case.test.js
+++ b/test/registry/edge_case.test.js
@@ -77,7 +77,7 @@ describe('test/registry/edge_case.test.js', () => {
     assert.deepEqual(val, [ 'bolt://127.0.0.2:12200', 'bolt://127.0.0.3:12200' ]);
     assert.deepEqual(firstVal, [ 'bolt://127.0.0.2:12200', 'bolt://127.0.0.3:12200' ]);
 
-    registry.close();
-    registry2.close();
+    await registry.close();
+    await registry2.close();
   });
 });

--- a/test/server/connection.test.js
+++ b/test/server/connection.test.js
@@ -80,7 +80,7 @@ describe('test/server/connection.test.js', () => {
     const address = urlparse('bolt://127.0.0.1:' + port + '?serialization=hessian2', true);
     const clientSocket = net.connect(port, '127.0.0.1');
     const socket = await awaitEvent(server, 'connection');
-    connection = new RpcConnection({ logger, socket, classMap });
+    connection = new RpcConnection({ logger, socket, classMap, parseRequestPropsWithHeader });
     await connection.ready();
 
     const opts = {

--- a/test/server/connection.test.js
+++ b/test/server/connection.test.js
@@ -14,6 +14,7 @@ const RpcConnection = require('../../lib/server/connection');
 const classMap = require('../fixtures/class_map');
 const logger = console;
 const proto = antpb.loadAll(path.join(__dirname, '../fixtures/proto'));
+const parseRequestPropsWithHeader = true;
 
 describe('test/server/connection.test.js', () => {
   let server;
@@ -87,6 +88,7 @@ describe('test/server/connection.test.js', () => {
       classCache: new Map(),
       address,
       classMap,
+      parseRequestPropsWithHeader,
     };
     const encoder = protocol.encoder(opts);
     const decoder = protocol.decoder(opts);

--- a/test/supports/pb_server.js
+++ b/test/supports/pb_server.js
@@ -10,14 +10,16 @@ const logger = console;
 const proto = require('antpb').loadAll(path.join(__dirname, '../fixtures/proto'));
 protocol.setOptions({ proto });
 
-const registry = new ZookeeperRegistry({
-  logger,
-  address: '127.0.0.1:2181',
-});
 
 let server;
+let registry;
 
 exports.start = async function() {
+  registry = new ZookeeperRegistry({
+    logger,
+    address: '127.0.0.1:2181',
+  });
+
   server = new RpcServer({
     appName: 'pb',
     logger: console,
@@ -47,4 +49,5 @@ exports.start = async function() {
 
 exports.close = async function() {
   await server.close();
+  await registry.close();
 };


### PR DESCRIPTION
https://github.com/sofastack/sofa-rpc/blob/master/remoting/remoting-bolt/src/main/java/com/alipay/sofa/rpc/codec/bolt/SofaRpcSerialization.java#L325
对齐 sofa-bolt 的实现，通过 parseRequestPropsWithHeader 的 decode option 配置 header 中的 rpc_trace_context 属性合并进 req
 